### PR TITLE
Added two missing tree families: Tnx0Vpnx1 and Tnx0Vnx1pnx2. Fixed bug in hierarchy parsing.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -148,7 +148,7 @@ def bracketToDict(bracket_string, node_feature_dict):
     else:
         # first node definitely dominates everything that comes after
         root = re.findall(final_nodename, bracket_string)[0]
-        rest = re.sub(root, "", bracket_string)
+        rest = bracket_string.replace(root, "")
 
         # divide rest into list of siblings (daughters to root)
         children = identify_siblings(rest, final_nodename)

--- a/xtag/english/grammar/Tnx0VPnx1.trees
+++ b/xtag/english/grammar/Tnx0VPnx1.trees
@@ -1,4 +1,4 @@
-("nx0Vpnx1" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+("nx0VPnx1" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 S_r.b:<extracted> = -
@@ -37,19 +37,19 @@ S_r.b:<progressive> = VP.t:<progressive>
 S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
-" :COMMENTS "Basic declarative tree for verbs which take prepositional
+" :COMMENTS "Basic declarative tree for verbs which take particular prepositional
 complements.  
 
-John ventured (into,around) the cave.
-The hikers slogged (through,over) the mud.
+John depends on Mary.
+John thought of a new idea.
 
 The VP_e node allows left adjunction between the verb and the preposition:
 
-John hikers slogged slowly through the mud.
+John depends often on Mary.
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("W0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("W0nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 
@@ -103,8 +103,8 @@ NP_1:<case> = PP.b:<assign-case>
 PP.b:<wh> = NP_1:<wh>
 " :COMMENTS "Wh on the subject
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) 
-("N0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) 
+("N0nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -121,8 +121,8 @@ NP_r.b:<agr> = NP_f.t:<agr>
 NP_r.b:<case> = NP_f.t:<case>
 S_r.b:<agr> = VP.t:<agr>
 S_r.b:<assign-case> = VP.t:<assign-case>
-S_r.b:<agr> = NP_0:<agr>
-S_r.b:<assign-case> = NP_0:<case>
+S_r.b:<agr> = NP_0.t:<agr>
+S_r.b:<assign-case> = NP_0.t:<case>
 VP.b:<passive> = V.t:<passive>
 V.t:<passive> = -
 VP.b:<agr> = V.t:<agr>
@@ -139,9 +139,9 @@ VP_e.b:<assign-comp> = none
 
 S_r.t:<conj> = nil
 
-NP_w.t:<trace> = NP_0:<trace>
-NP_w.t:<case> = NP_0:<case>
-NP_w.t:<agr> = NP_0:<agr>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
 NP_w.t:<wh> = +
 S_r.t:<comp> = nil
 NP_r.b:<rel-clause> = +
@@ -152,9 +152,14 @@ PP.b:<wh> = NP_1:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "Subject relative clause:
-\"...the man who ventured into the cave...\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
-("W1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+\"...the man who depends on Mary...\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("W1nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
 
 
 
@@ -211,11 +216,11 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Wh & topicalization on NP1:
-   \"What did John venture into?\"
-   \"The cave John ventured into. (The haunted house he didn't)\"
+   \"Who does John depend on?\"
+   \"Mary John depends on. (Emma he doesn't)\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("NP" . "1")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
-("N1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("NP" . "1")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N1nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<mode> = VP.t:<mode>
 S_r.b:<assign-comp> = VP.t:<assign-comp>
@@ -266,10 +271,17 @@ NP_f.b:<case> = nom/acc
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "Object relative:
-    \"...the cave that John venture into...\"
+    \"...the woman that John depends on...\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
-("pW1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("pW1nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
 
 
 
@@ -321,10 +333,10 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Fronted PP-complement:
-	\"Into the cave he ventured.\"
+    \"On these they feel they can rely.\" (Brown corpus)
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
-("Inx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Inx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 S_r.b:<extracted> = -
@@ -362,6 +374,7 @@ VP_e.b:<mainv> = -
 VP_e.b:<compar> = -
 VP_e.b:<assign-comp> = none
 
+V.b:<mode> = base
 P.t:<assign-case> = PP.b:<assign-case>
 NP_1:<case> = PP.b:<assign-case>
 PP.b:<wh> = NP_1:<wh>
@@ -370,10 +383,17 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Imperative:
-    \"Glance through these documents!\"
+    \"Think of an answer!\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("Dnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Dnx0VPnx1" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
 
 
 
@@ -396,9 +416,16 @@ P.t:<assign-case> = PP.b:<assign-case>
 NP_1:<case> = PP.b:<assign-case>
 PP.b:<wh> = NP_1:<wh>
 " :COMMENTS "PP-complement: determiner gerund
-   \"His venturing into the cave bothered me greatly.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . ""))) (((("D" . "")) :substp T))  (((("N" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+   \"His depending entirely on Mary bothered me greatly.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . ""))) (((("D" . "")) :substp T))  (((("N" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
 
 
 
@@ -448,9 +475,10 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Passive with by-phrase:
-    \"The corn field was trampled on by the children.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
-("nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+    \"The idea was thought of by John.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("nx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
 
 
 
@@ -498,10 +526,17 @@ V.t:<passive> = +
 V.t:<mode> = ppart
 V.t:<punct struct> = nil
 " :COMMENTS "Passive:
-   \"The cornfield was trampled on.\"
+   \"The idea was thought of.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) ) ) ) 
-("pW0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :headp T)) ) ) ) ) 
+("pW0nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
 
 
 
@@ -559,11 +594,11 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Wh question on NP0 in passive constructions, by-phrase extracted:
-    \"By whom was the cornfield trampled on?\"
+    \"By whom was the idea thought of?\"
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "by")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) 
-("W1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :headp T)) ) )  (((("PP" . "by")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) 
+("W1nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 
@@ -617,15 +652,13 @@ S_r.t:<conj> = nil
 PP_0.b:<wh> = NP_0:<wh>
 P.t:<assign-case> = PP.b:<assign-case>
 NP_1:<case> = PP.b:<assign-case>
-PP.b:<wh> = NP_1:<wh>
-" :COMMENTS "Wh question on NP1 in passive constructions
-    \"What was trampled on by the children?\"
+PP.b:<wh> = NP_1:<wh>" :COMMENTS "Wh question on NP1 in passive constructions
+    \"What was thought of by Bob?\"
 
+    
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) 
-("W1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
-
-
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) 
+("W1nx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 
@@ -644,11 +677,11 @@ S_q.b:<wh> = NP_1:<wh>
 S_r.b:<inv> = -
 S_q.b:<mode> = S_r.t:<mode>
 S_q.b:<comp> = nil
-NP.t:<agr> = NP.t:<agr>
-NP.t:<case> = NP.t:<case>
-NP.t:<wh> = NP.t:<wh>
+NP_1:<agr> = NP.t:<agr>
+NP_1:<case> = NP.t:<case>
+NP_1:<wh> = NP.t:<wh>
 NP.t:<wh> = +
-NP.t:<trace> = NP.t:<trace>
+NP_1:<trace> = NP.t:<trace>
 S_r.b:<mode> = VP.t:<mode>
 S_r.b:<comp> = nil
 S_r.b:<tense> = VP.t:<tense>
@@ -677,11 +710,12 @@ P.t:<assign-case> = PP.b:<assign-case>
 NP_1:<case> = PP.b:<assign-case>
 PP.b:<wh> = NP_1:<wh>
 " :COMMENTS "Wh question on NP1 in passive constructions
-    \"What was trampled on?\"
-	
+    \"What was thought of?\"
+
+    
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) 
-("N0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) ) 
+("N0nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -734,10 +768,10 @@ PP_0.b:<wh> = NP_0:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-	(I know) the person that the idea was thought of by.\"
+    (I know) the person that the idea was thought of by.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
-("N1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N1nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -789,10 +823,10 @@ PP_0.b:<wh> = NP_0:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction from NP1:
-   \"(I heard that) the corn field was trampled on by the children.\"
+   \"(I heard) the idea that was thought of by John.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
-("N1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("N1nx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -840,11 +874,11 @@ NP_f.b:<case> = nom/acc
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction from NP1:
-    \"(I saw) the field that was trampled on.\"
+    \"(I saw) the woman that was depended on.\"
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
-("Nbynx0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) ) ) 
+("Nbynx0nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -897,10 +931,10 @@ NP_f.b:<case> = nom/acc
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-   \"(I know) the person by whom the cave was ventured into.\"
+   \"(I know) the person by whom the idea was thought of.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "w")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
-("Npxnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "w")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Npxnx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -950,10 +984,10 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct relative clause:
-   \"the day on which John ventured into the cave (was very joyous).\"
+   \"the day on which John thought of the idea (was very joyous).\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
-("Npxnx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Npxnx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1005,9 +1039,9 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct relative clause on passive:
-   \"the day on which the field was trampled on by the children\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
-("Npxnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+   \"the day on which the idea was thought of by John\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Npxnx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1055,10 +1089,10 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct extraction from passive:
-   \"the day on which the field was trampled on (was very joyous).\"
+   \"the day on which the idea was thought of (was very joyous).\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
-("Npx1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) ) ) 
+("Npx1nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<mode> = VP.t:<mode>
 S_r.b:<assign-comp> = VP.t:<assign-comp>
@@ -1110,9 +1144,9 @@ PP.b:<wh> = NP_1:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "Relative clause on fronted PP:
-   \"the field on which the children trampled (is ruined).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
-("Nc0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+   \"the person on whom John depends (is Mary).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nc0nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -1161,9 +1195,9 @@ PP.b:<wh> = NP_1:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "Relative clause on NP0:
-  \"the man that ventured into the cave (slept soundly).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
-("Nc1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+  \"the man that depends on Mary (slept soundly).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Nc1nx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<mode> = VP.t:<mode>
 S_r.b:<assign-comp> = VP.t:<assign-comp>
@@ -1215,10 +1249,10 @@ NP_f.b:<case> = nom/acc
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "Relative clause on NP1:
-   \"the cave that John ventured into (was dark).\"
+   \"the woman that John depends on (slept soundly).\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
-("Nc0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("Nc0nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -1272,10 +1306,10 @@ PP_0.b:<wh> = NP_0:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-   \"(I know) the children that the field was trampled on by.\"
+   \"(I know) the person that the idea was thought of by.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
-("Nc1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nc1nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -1328,10 +1362,10 @@ PP_0.b:<wh> = NP_0:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction from NP1:
-   \"(I saw) the field that was trampled on by the children.\"
+   \"(I saw) the woman that was depended on by John.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
-("Nc1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Nc1nx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 
@@ -1380,11 +1414,11 @@ NP_f.b:<case> = nom/acc
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction from NP1:
-   \"(I saw) the field that was trampled on.\"
+   \"(I saw) the woman that was depended on.\"
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
-("Ncnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) ) ) 
+("Ncnx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1436,10 +1470,10 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct relative clause:
-   \"the day that John ventured into the cave (was joyous).\"
+   \"the day that John thought of the idea (was joyous).\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
-("Ncnx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Ncnx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1493,9 +1527,9 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct relative clause with passive:
-   \"(I remember) the day that the field was trampled on by the children.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
-("Ncnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+   \"(I remember) the day that the idea was thought of by John.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Ncnx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1545,10 +1579,16 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Adjunct relative clause with passive:
-   \"(I remember) the day that the field was trampled on.\"
+   \"(I remember) the day that the idea was thought of.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
-("W0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) ) ) 
+("W0nx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
 
 
 
@@ -1610,11 +1650,11 @@ S_r.b:<perfect> = VP.t:<perfect>
 S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 " :COMMENTS "Wh & topicalization on passivized NP0:
-  \"Who was the cave ventured into by?\"
-  \"John the cave was ventured into by.\"
+  \"Who was the idea thought of by?\"
+  \"John the idea was thought of by.\"
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "q"))) (((("NP" . "0")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
-("Gnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+ (((("S" . "q"))) (((("NP" . "0")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Gnx0VPnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
 
 
 NP_r.b:<case> = nom/acc
@@ -1639,12 +1679,13 @@ VP_e.b:<assign-comp> = none
 
 V.t:<passive> = -
 NP_0:<case> = acc/gen
-" :COMMENTS "PP-complement - NP gerund
- 
-[John('s) venturing into the cave] was dangerous.
+" :COMMENTS "Multi Anchor PP-complement - NP gerund
+
+[John('s) depending on Mary] was difficult for her mother.
+
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("Gnx1Vpbnx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Gnx1VPbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 NP_r.b:<case> = nom/acc
@@ -1672,12 +1713,13 @@ P_0.b:<assign-case> = acc
 PP_0.b:<wh> = NP_0:<wh>
 NP_0:<case> = PP_0.b:<assign-case>
 NP_1:<case> = acc/gen
-" :COMMENTS "PP-complement - gerund passive with the by-phrase
+" :COMMENTS "Multi Anchor PP-complement - gerund passive with the by-phrase
    
-...the cave('s) being ventured into by John...
+...the idea('s) being thought of by John...
+
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
-("Gnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1VP" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 
 NP_r.b:<case> = nom/acc
@@ -1701,12 +1743,13 @@ V.t:<mode> = ppart
 V.t:<passive> = +
 PP.b:<wh> = NP_1:<wh>
 NP_1:<case> = acc/gen
-" :COMMENTS "PP-complement - gerund passive without the by-phrase
+" :COMMENTS "Multi Anchor PP-complement - gerund passive without the by-phrase:
+ 
+...John('s) being depended on...
 
-...the cave('s) being ventured into...
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) 
-("nx0Vpnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) 
+("nx0VPnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1743,20 +1786,15 @@ S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 VP.t:<mode> = inf/ger
 
-" :COMMENTS "PP Complement - PRO subject  
-
-John wanted [PRO to venture (into,around) the cave].
-While [PRO slogging (through,over) the mud] the hikers got dirty.
+" :COMMENTS "Multi Anchor PP complement - PRO subject
 
 
-The VP_e node allows left adjunction between the verb and the preposition:
-
-... slog slowly through the mud.
+John wants [PRO to think of a new idea].
 
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("nx1Vpbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("nx1VPbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<extracted> = -
 S_r.b:<inv> = -
@@ -1798,21 +1836,19 @@ S_r.b:<passive> = VP.t:<passive>
 S_r.b:<mainv> = VP.t:<mainv>
 VP.t:<mode> = inf/ger
 
-" :COMMENTS "PP Complement - Passive with by-phrase, w/ PRO subject
-    
-The men didn't want [PRO to be trampled on by the bulls].
-While [PRO being trampled on by the bulls] the men screamed.
+" :COMMENTS "Multi Anchor PP complement - Passive with by-phrase, w/ PRO subject
 
+John wanted [PRO to be depended on by his kids].
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
-("nx1Vp-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("nx1VP-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 S_r.b:<inv> = -
 S_r.b:<comp> = nil
 S_r.b:<extracted> = -
 S_r.b:<wh> = NP_1:<wh>
-S_r.b:<assign-case> = NP_1.t:<case>
 S_r.b:<agr> = NP_1:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
 S_r.b:<control> = NP_1.t:<control>
 S_r.b:<agr> = VP.t:<agr>
 S_r.b:<mode> = VP.t:<mode>
@@ -1823,7 +1859,7 @@ S_r.b:<passive> = VP.t:<passive>
 S_r.b:<progressive> = VP.t:<progressive>
 S_r.b:<assign-comp> = VP.t:<assign-comp>
 NP_1:<wh> = -
-NP_0.t:<case> = none
+NP_1.t:<case> = none
 VP.b:<compar> = -
 VP.b:<agr> = V.t:<agr>
 VP.b:<mode> = V.t:<mode>
@@ -1841,13 +1877,13 @@ V.t:<mode> = ppart
 V.t:<punct struct> = nil
 VP.t:<mode> = inf/ger
 
-" :COMMENTS "PP Complement - Passive w/o by-phrase, w/ PRO subject
+" :COMMENTS "Multi Anchor PP complement - Passive w/o by-phrase, w/ PRO subject
 
-The men didn't want [PRO to be trampled on].
-While [PRO being trampled on] the men screamed.
+John wanted [PRO to be depended on].
+
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) ) ) ) 
-("Gnx0Vpnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :headp T)) ) ) ) ) 
+("Gnx0VPnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
 
 NP_r.b:<case> = nom/acc
 NP_r.b:<agr num> = sing
@@ -1868,16 +1904,15 @@ VP_e.b:<mainv> = -
 VP_e.b:<compar> = -
 VP_e.b:<mode> = base
 VP_e.b:<assign-comp> = none
-
 V.t:<passive> = -
 
+" :COMMENTS "Multi Anchor PP-complement - NP gerund w/ PRO subject
 
-" :COMMENTS "PP-complement - NP gerund w/ PRO subject
- 
-[PRO venturing into the cave] was dangerous for John.
+[PRO thinking of ideas] makes John feel good.
+
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
-("Gnx1Vpbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Gnx1VPbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 NP_r.b:<case> = nom/acc
 NP_r.b:<agr num> = sing
@@ -1885,8 +1920,8 @@ NP_r.b:<agr pers> = 3
 NP_r.b:<agr 3rdsing> = +
 NP_r.b:<gerund> = +
 NP_1:<wh> = NP_r.b:<wh>
-NP_1.t:<case> = none
 NP_1.t:<wh> = -
+NP_1.t:<case> = none
 VP.t:<mode> = ger
 VP.b:<mode> = V.t:<mode>
 VP.b:<passive> = V.t:<passive>
@@ -1904,13 +1939,13 @@ P_0.b:<assign-case> = acc
 PP_0.b:<wh> = NP_0:<wh>
 NP_0:<case> = PP_0.b:<assign-case>
 
-" :COMMENTS "PP-complement - gerund passive with the by-phrase, w/ PRO subject
-   
-[PRO being trampled on by John] was bad for the field.
+" :COMMENTS "Multi Anchor PP-complement - gerund passive with the by-phrase, PRO subject
+
+[PRO being depended on by John] made Mary happy.
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
-("Gnx1Vp-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1VP-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
 
 NP_r.b:<case> = nom/acc
 NP_r.b:<agr num> = sing
@@ -1933,15 +1968,9 @@ V.t:<mode> = ppart
 V.t:<passive> = +
 PP.b:<wh> = NP_1:<wh>
 
-" :COMMENTS "PP-complement - gerund passive without the by-phrase, w/ PRO subject
+" :COMMENTS "Multi Anchor PP-complement - gerund passive w/o the by-phrase, w/ PRO subject
 
-[PRO being trampled on] was bad for the field.
+[PRO being depended on] made John happy.
 
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
- (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) 
-
-
-
-
-
-
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T)) ) ) ) ) 

--- a/xtag/english/grammar/Tnx0V_pnx1.trees
+++ b/xtag/english/grammar/Tnx0V_pnx1.trees
@@ -1,0 +1,1947 @@
+("nx0Vpnx1" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = VP_e.t:<compar>
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.b:<control> = NP_0.t:<control>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Basic declarative tree for verbs which take prepositional
+complements.  
+
+John ventured (into,around) the cave.
+The hikers slogged (through,over) the mud.
+
+The VP_e node allows left adjunction between the verb and the preposition:
+
+John hikers slogged slowly through the mud.
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("W0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<wh> = NP_0.t:<wh>
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_q.b:<comp> = nil
+S_q.b:<mode> = S_r.t:<mode>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<inv> = -
+NP:<trace> = NP_0.t:<trace>
+NP:<agr> = NP_0.t:<agr>
+NP:<case> = NP_0.t:<case>
+NP.t:<wh> = NP_0.t:<wh>
+NP_0:<wh> = +
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.t:<conj> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+" :COMMENTS "Wh on the subject
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) 
+("N0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<inv> = -
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_0:<agr>
+S_r.b:<assign-case> = NP_0:<case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP_0:<trace>
+NP_w.t:<case> = NP_0:<case>
+NP_w.t:<agr> = NP_0:<agr>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "Subject relative clause:
+\"...the man who ventured into the cave...\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("W1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_q.b:<comp> = nil
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<inv> = -
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_1:<wh> = S_q.b:<wh>
+NP.t:<trace> = NP_1.t:<trace>
+NP.t:<agr> = NP_1.t:<agr>
+NP.t:<case> = NP_1.t:<case>
+NP.t:<wh> = NP_1.t:<wh>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP:<wh>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Wh & topicalization on NP1:
+   \"What did John venture into?\"
+   \"The cave John ventured into. (The haunted house he didn't)\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP_1:<wh>
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP_0.t:<control>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "Object relative:
+    \"...the cave that John venture into...\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("pW1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+PP_1:<trace> = PP.t:<trace>
+S_q.b:<wh> = PP_1:<wh>
+S_r.b:<tense> = VP.t:<tense>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Fronted PP-complement:
+	\"Into the cave he ventured.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Inx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = imp
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+NP_0:<agr pers> = 2
+NP_0:<agr 3rdsing> = -
+NP_0:<agr num> = plur/sing
+NP_0:<case> = nom
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.t:<neg> = -
+VP.t:<mode> = base
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.t:<tense> = pres
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<assign-comp> = none
+
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Imperative:
+    \"Glance through these documents!\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Dnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+NP.b:<const> = D.t:<const>
+NP.b:<definite> = D.t:<definite>
+NP.b:<quan> = D.t:<quan>
+NP.b:<card> = D.t:<card>
+NP.b:<gen> = D.t:<gen>
+NP.b:<decreas> = D.t:<decreas>
+NP.b:<wh> = D.t:<wh>
+V.t:<mode> = ger
+NP.b:<case> = nom/acc
+NP.b:<agr num> = sing
+NP.b:<agr pers> = 3
+NP.b:<agr 3rdsing> = +
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+" :COMMENTS "PP-complement: determiner gerund
+   \"His venturing into the cave bothered me greatly.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . ""))) (((("D" . "")) :substp T))  (((("N" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.b:<control> = NP.t:<control>
+PP_0.b:<wh> = NP_0:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Passive with by-phrase:
+    \"The corn field was trampled on by the children.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+S_r.b:<inv> = -
+S_r.b:<comp> = nil
+S_r.b:<extracted> = -
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<agr> = NP_1:<agr>
+S_r.b:<assign-case> = NP_1:<case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<mainv> = VP.t:<mainv>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+NP_1:<wh> = -
+
+VP.b:<compar> = -
+
+VP.b:<agr> = V.t:<agr>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+
+V.t:<passive> = +
+V.t:<mode> = ppart
+V.t:<punct struct> = nil
+" :COMMENTS "Passive:
+   \"The cornfield was trampled on.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) ) ) ) 
+("pW0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+P_0.b:<assign-case> = acc
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+
+
+
+NP_0:<case> = PP_0.b:<assign-case>
+PP_0.b:<wh> = NP_0:<wh>
+S_q.b:<wh> = PP_0.t:<wh>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+PP.t:<trace> = PP_0.t:<trace>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP.t:<control>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Wh question on NP0 in passive constructions, by-phrase extracted:
+    \"By whom was the cornfield trampled on?\"
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "by")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) 
+("W1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_q.b:<wh> = NP_1:<wh>
+S_r.b:<inv> = -
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+NP_1:<agr> = NP.t:<agr>
+NP_1:<case> = NP.t:<case>
+NP.t:<wh> = +
+NP_1:<trace> = NP.t:<trace>
+NP_1:<wh> = NP.t:<wh>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+PP_0.b:<wh> = NP_0:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+" :COMMENTS "Wh question on NP1 in passive constructions
+    \"What was trampled on by the children?\"
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) 
+("W1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_q.b:<wh> = NP_1:<wh>
+S_r.b:<inv> = -
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+NP.t:<agr> = NP.t:<agr>
+NP.t:<case> = NP.t:<case>
+NP.t:<wh> = NP.t:<wh>
+NP.t:<wh> = +
+NP.t:<trace> = NP.t:<trace>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+S_r.t:<conj> = nil
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+" :COMMENTS "Wh question on NP1 in passive constructions
+    \"What was trampled on?\"
+	
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) 
+("N0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP.t:<control>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+	(I know) the person that the idea was thought of by.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.t:<mode> = ind/inf/ppart
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction from NP1:
+   \"(I heard that) the corn field was trampled on by the children.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("N1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.t:<mode> = ind/inf/ppart
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction from NP1:
+    \"(I saw) the field that was trampled on.\"
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
+("Nbynx0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP.t:<control>
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+PP_w.t:<trace> = PP_0.b:<trace>
+PP_w.t:<case> = PP_0.b:<case>
+PP_w.t:<agr> = PP_0.b:<agr>
+PP_w.b:<assign-case> = P_0.t:<assign-case>
+PP_w.b:<assign-case> = NP_w.t:<case>
+PP_w.b:<wh> = NP_w.t:<wh>
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+   \"(I know) the person by whom the cave was ventured into.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "w")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Npxnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<inv> = -
+PP_w.t:<wh> = +
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct relative clause:
+   \"the day on which John ventured into the cave (was very joyous).\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Npxnx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.b:<control> = NP.t:<control>
+S_r.t:<inv> = -
+PP_w.t:<wh> = +
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct relative clause on passive:
+   \"the day on which the field was trampled on by the children\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Npxnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+S_r.b:<control> = NP.t:<control>
+S_r.t:<inv> = -
+PP_w.t:<wh> = +
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<comp> = nil
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct extraction from passive:
+   \"the day on which the field was trampled on (was very joyous).\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
+("Npx1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<comp> = nil
+PP_w.t:<trace> = PP.b:<trace>
+PP_w.t:<case> = PP.b:<case>
+PP_w.t:<agr> = PP.b:<agr>
+PP_w.t:<wh> = +
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP_w.b:<assign-case>
+NP_1:<case> = PP_w.b:<assign-case>
+PP_w.b:<wh> = NP_1:<wh>
+PP.b:<wh> = NP_1:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "Relative clause on fronted PP:
+   \"the field on which the children trampled (is ruined).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nc0nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<inv> = -
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_0.t:<agr>
+S_r.b:<assign-case> = NP_0.t:<case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+NP_r.b:<rel-clause> = +
+S_r.t:<mode> = inf/ger/ind
+S_r.t:<nocomp-mode> = inf/ger
+VP.t:<assign-comp> = that/ind_nil/inf_nil/ecm
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "Relative clause on NP0:
+  \"the man that ventured into the cave (slept soundly).\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Nc1nx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP_1:<wh>
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP_0.t:<control>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_r.b:<rel-clause> = +
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "Relative clause on NP1:
+   \"the cave that John ventured into (was dark).\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("Nc0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+
+S_r.b:<control> = NP.t:<control>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+NP_r.b:<rel-clause> = +
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+   \"(I know) the children that the field was trampled on by.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nc1nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_r.b:<rel-clause> = +
+S_r.t:<mode> = inf/ger/ind/ppart
+S_r.t:<nocomp-mode> = ind/ger/ppart
+VP.t:<assign-comp> = that/inf_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction from NP1:
+   \"(I saw) the field that was trampled on by the children.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Nc1nx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+S_r.t:<conj> = nil
+
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_r.b:<rel-clause> = +
+S_r.t:<mode> = inf/ger/ind/ppart
+S_r.t:<nocomp-mode> = ind/ger/ppart
+VP.t:<assign-comp> = that/inf_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction from NP1:
+   \"(I saw) the field that was trampled on.\"
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
+("Ncnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.b:<control> = NP_0.t:<control>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<inv> = -
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct relative clause:
+   \"the day that John ventured into the cave (was joyous).\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) ) ) 
+("Ncnx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.b:<control> = NP.t:<control>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<inv> = -
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct relative clause with passive:
+   \"(I remember) the day that the field was trampled on by the children.\"" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Ncnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+S_r.b:<control> = NP.t:<control>
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_f.b:<case> = acc/nom
+S_r.t:<inv> = -
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+NP_r.b:<pron> = NP_f.t:<pron>
+
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Adjunct relative clause with passive:
+   \"(I remember) the day that the field was trampled on.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) ) ) 
+("W0nx1Vpbynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<control> = NP_1:<control>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+V.t:<mode> = ppart
+V.t:<passive> = +
+V.t:<punct struct> = nil
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP.t:<case>
+PP_0.b:<wh> = NP.t:<wh>
+P_0.b:<assign-case> = acc
+
+S_q.b:<wh> = NP_0:<wh>
+S_q.b:<extracted> = +
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+S_r.t:<comp> = nil
+S_r.t:<conj> = nil
+V.t:<punct struct> = nil
+NP.t:<trace> = NP_0.t:<trace>
+NP.t:<agr> = NP_0.t:<agr>
+NP.t:<case> = NP_0.t:<case>
+NP.t:<wh> = NP_0.t:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+" :COMMENTS "Wh & topicalization on passivized NP0:
+  \"Who was the cave ventured into by?\"
+  \"John the cave was ventured into by.\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "0")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Gnx0Vpnx1" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+
+NP_0:<wh> = NP_r.b:<wh>
+VP.t:<mode> = ger
+
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<passive> = -
+NP_0:<case> = acc/gen
+" :COMMENTS "PP-complement - NP gerund
+ 
+[John('s) venturing into the cave] was dangerous.
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Gnx1Vpbnx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+
+NP_1:<wh> = NP_r.b:<wh>
+VP.t:<mode> = ger
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP.b:<wh> = NP_1:<wh>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P_0.b:<assign-case> = acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_0:<case> = PP_0.b:<assign-case>
+NP_1:<case> = acc/gen
+" :COMMENTS "PP-complement - gerund passive with the by-phrase
+   
+...the cave('s) being ventured into by John...
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1Vp" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+
+NP_1:<wh> = NP_r.b:<wh>
+VP.t:<mode> = ger
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP.b:<wh> = NP_1:<wh>
+NP_1:<case> = acc/gen
+" :COMMENTS "PP-complement - gerund passive without the by-phrase
+
+...the cave('s) being ventured into...
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) 
+("nx0Vpnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+S_r.b:<assign-case> = NP_0.t:<case>
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<wh> = -
+NP_0.t:<case> = none
+S_r.b:<agr> = VP.t:<agr>
+VP.b:<passive> = V.t:<passive>
+V.t:<passive> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = VP_e.t:<compar>
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+S_r.b:<control> = NP_0.t:<control>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "PP Complement - PRO subject  
+
+John wanted [PRO to venture (into,around) the cave].
+While [PRO slogging (through,over) the mud] the hikers got dirty.
+
+
+The VP_e node allows left adjunction between the verb and the preposition:
+
+... slog slowly through the mud.
+
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("nx1Vpbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<assign-case> = NP_1.t:<case>
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<wh> = -
+NP_1.t:<case> = none
+S_r.b:<agr> = VP.t:<agr>
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+S_r.b:<control> = NP.t:<control>
+PP_0.b:<wh> = NP_0:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "PP Complement - Passive with by-phrase, w/ PRO subject
+    
+The men didn't want [PRO to be trampled on by the bulls].
+While [PRO being trampled on by the bulls] the men screamed.
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("nx1Vp-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<inv> = -
+S_r.b:<comp> = nil
+S_r.b:<extracted> = -
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.b:<agr> = NP_1:<agr>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<mainv> = VP.t:<mainv>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+NP_1:<wh> = -
+NP_0.t:<case> = none
+VP.b:<compar> = -
+VP.b:<agr> = V.t:<agr>
+VP.b:<mode> = V.t:<mode>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<tense> = V.t:<tense>
+VP.b:<passive> = V.t:<passive>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<passive> = +
+V.t:<mode> = ppart
+V.t:<punct struct> = nil
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "PP Complement - Passive w/o by-phrase, w/ PRO subject
+
+The men didn't want [PRO to be trampled on].
+While [PRO being trampled on] the men screamed.
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "NA" :constraint-type :NA) (((("P" . "")) :substp T)) ) ) ) ) 
+("Gnx0Vpnx1-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+NP_0:<wh> = NP_r.b:<wh>
+NP_0.t:<wh> = -
+NP_0.t:<case> = none
+VP.t:<mode> = ger
+P.t:<assign-case> = PP.b:<assign-case>
+NP_1:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_1:<wh>
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<passive> = -
+
+
+" :COMMENTS "PP-complement - NP gerund w/ PRO subject
+ 
+[PRO venturing into the cave] was dangerous for John.
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "1")) :substp T)) ) ) ) ) 
+("Gnx1Vpbynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+NP_1:<wh> = NP_r.b:<wh>
+NP_1.t:<case> = none
+NP_1.t:<wh> = -
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP.b:<wh> = NP_1:<wh>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P_0.b:<assign-case> = acc
+PP_0.b:<wh> = NP_0:<wh>
+NP_0:<case> = PP_0.b:<assign-case>
+
+" :COMMENTS "PP-complement - gerund passive with the by-phrase, w/ PRO subject
+   
+[PRO being trampled on by John] was bad for the field.
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1Vp-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+NP_1:<wh> = NP_r.b:<wh>
+NP_1.t:<case> = none
+NP_1.t:<wh> = -
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+PP.b:<wh> = NP_1:<wh>
+
+" :COMMENTS "PP-complement - gerund passive without the by-phrase, w/ PRO subject
+
+[PRO being trampled on] was bad for the field.
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T)) ) ) ) ) 
+
+
+
+
+
+

--- a/xtag/english/grammar/Tnx0Vnx1Pnx2.trees
+++ b/xtag/english/grammar/Tnx0Vnx1Pnx2.trees
@@ -98,7 +98,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive:
-	the poodle was put in the oven by Max
+    the poodle was put in the oven by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
 ("W0nx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -615,7 +615,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive w/out by-phrase:
-	the poodle was put in the oven
+    the poodle was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
 ("W0nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -681,7 +681,7 @@ PP_0.b:<wh> = NP:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction from by-phrase:
-	who was the poodle put in the oven by
+    who was the poodle put in the oven by
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
 ("pW0nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -745,7 +745,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction of by-phrase:
-	by whom was the poodle put in the oven
+    by whom was the poodle put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) 
 ("W2nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -807,7 +807,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction of NP2:
-	what was the poodle put in by Max
+    what was the poodle put in by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("NP" . "2")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) 
 ("W2nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -865,7 +865,7 @@ PP.b:<wh> = NP.t:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction of NP2, w/0 by-phrase:
-	what was the poodle put in
+    what was the poodle put in
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("NP" . "2")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
 ("N1nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -923,7 +923,7 @@ V.t:<mode> = ppart
 V.t:<assign-comp> = ppart_nil
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction from NP1:
-	(I saw) the dog that was put in the oven by Max
+    (I saw) the dog that was put in the oven by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
 ("N1nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -975,7 +975,7 @@ V.t:<mode> = ppart
 V.t:<assign-comp> = ppart_nil
 V.t:<passive> = +
 " :COMMENTS "Passive that relative clause, extraction from NP1, w/o by-phrase:
-	(I saw) the dog that was put in the oven
+    (I saw) the dog that was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
 ("W1nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1038,8 +1038,8 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Wh question on NP1 in passive constructions, with by-phrase
-	what was put in the oven by Max
-	
+    what was put in the oven by Max
+    
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) 
 ("W1nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1098,7 +1098,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Wh question on NP1 in passive constructions, w/o by-phrase
-	what was put in the oven
+    what was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) 
 ("pW2nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1157,7 +1157,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction of NP2, w/o by-phrase:
-	where was the poodle put by Max
+    where was the poodle put by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
 ("pW2nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1220,7 +1220,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "passive, extraction of NP2:
-	where was the poodle put by Max
+    where was the poodle put by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) 
 ("N2nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1279,7 +1279,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object
-	(I saw) the oven that the poodle was put in by Max
+    (I saw) the oven that the poodle was put in by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
 ("N2nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1334,7 +1334,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
-	(I saw) the oven that the poodle was put in
+    (I saw) the oven that the poodle was put in
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
 ("N0nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1393,7 +1393,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-	(I saw) the person that the poodle was put in the oven by
+    (I saw) the person that the poodle was put in the oven by
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
 ("Nbynx0nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1452,7 +1452,7 @@ PP.b:<wh> = NP_2:<wh>
 NP_r.b:<pron> = NP_f.t:<pron>
 
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-	(I saw) the person that the poodle was put in the oven by
+    (I saw) the person that the poodle was put in the oven by
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "w")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
 ("Npxnx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1563,7 +1563,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive:
-	the poodle was put in the oven by Max
+    the poodle was put in the oven by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
 ("Npxnx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1617,7 +1617,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive w/out by-phrase:
-	the poodle was put in the oven
+    the poodle was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
 ("Npx2nx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1730,7 +1730,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object
-	(I saw) the oven that the poodle was put in by Max
+    (I saw) the oven that the poodle was put in by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
 ("Npx2nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -1786,7 +1786,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
-	(I saw) the oven that the poodle was put in
+    (I saw) the oven that the poodle was put in
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
 ("Nc0nx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2000,7 +2000,7 @@ V.t:<mode> = ppart
 V.t:<assign-comp> = ppart_nil
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction from NP1:
-	(I saw) the dog that was put in the oven by Max
+    (I saw) the dog that was put in the oven by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
 ("Nc1nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2054,7 +2054,7 @@ V.t:<mode> = ppart
 V.t:<assign-comp> = ppart_nil
 V.t:<passive> = +
 " :COMMENTS "Passive that relative clause, extraction from NP1, w/o by-phrase:
-	(I saw) the dog that was put in the oven
+    (I saw) the dog that was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
 ("Nc2nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2113,7 +2113,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object
-	(I saw) the oven that the poodle was put in by Max
+    (I saw) the oven that the poodle was put in by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
 ("Nc2nx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2168,7 +2168,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
-	(I saw) the oven that the poodle was put in
+    (I saw) the oven that the poodle was put in
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
 ("Nc0nx1VPnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2227,7 +2227,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
-	(I saw) the person that the poodle was put in the oven by
+    (I saw) the person that the poodle was put in the oven by
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
 ("Ncnx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2342,7 +2342,7 @@ PP_0.b:<wh> = NP_0:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive:
-	the poodle was put in the oven by Max
+    the poodle was put in the oven by Max
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
 ("Ncnx1VPnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
@@ -2398,7 +2398,7 @@ PP.b:<wh> = NP_2:<wh>
 V.t:<mode> = ppart
 V.t:<passive> = +
 " :COMMENTS "Passive w/out by-phrase:
-	the poodle was put in the oven
+    the poodle was put in the oven
 " :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
  (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :headp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
 ("Gnx0Vnx1Pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? T :UNIFICATION-EQUATIONS "
@@ -2592,7 +2592,7 @@ VP.t:<mode> = inf/ger
 
 " :COMMENTS "Multi Anchor Ditransitive with PP
 Passive w/ by-phrase, w/ PRO subject
-	
+    
 The poodle didn't want [PRO to be put in the oven by Max].
 While [PRO being given to the customer by the clerk] the parrot flew away.
 

--- a/xtag/english/grammar/Tnx0Vnx1_pnx2.trees
+++ b/xtag/english/grammar/Tnx0Vnx1_pnx2.trees
@@ -1,0 +1,2742 @@
+("nx0Vnx1pnx2" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = VP_e.t:<compar>
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "Ditransitive with PP
+
+He put his reputation on the line.
+
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive:
+	the poodle was put in the oven by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("W0nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<wh> = NP_0:<wh>
+S_q.b:<comp> = nil
+S_q.b:<mode> = S_r.t:<mode>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<wh> = +
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP:<trace> = NP_0.t:<trace>
+NP:<agr> = NP_0.t:<agr>
+NP:<case> = NP_0.t:<case>
+NP.t:<wh> = NP_0.t:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) 
+("N0nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.t:<inv> = -
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_0.t:<agr>
+S_r.b:<assign-case> = NP_0.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+NP_w.t:<wh> = +
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("W1nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_1:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_2:<case> = PP.b:<assign-case>
+NP.t:<case> = acc
+NP:<trace> = NP_1.t:<trace>
+NP:<agr> = NP_1.t:<agr>
+NP:<case> = NP_1.t:<case>
+NP.t:<wh> = NP_1.t:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) 
+("N1nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_1.t:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+NP_w.t:<wh> = +
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("W2nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_2:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_1:<case> = acc
+NP_2:<case> = NP.t:<case>
+NP_2:<agr> = NP.t:<agr>
+NP_2:<trace> = NP.t:<trace>
+NP_2:<wh> = NP.t:<wh>
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP.t:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "2")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N2nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.t:<mode> = ind/inf
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0.t:<agr> = S_r.b:<agr>
+NP_0.t:<case> = S_r.b:<assign-case>
+NP_1.t:<case> = acc
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("pW2nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = PP_2:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+PP_2:<trace> = PP.t:<trace>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Inx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = imp
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.t:<neg> = -
+VP.t:<mode> = base
+VP.b:<mode> = V.t:<mode>
+
+VP.t:<tense> = pres
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+NP_0:<agr pers> = 2
+NP_0:<agr 3rdsing> = -
+NP_0:<agr num> = plur/sing
+NP_0:<case> = nom
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "no comments
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("Dnx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP.b:<const> = D.t:<const>
+NP.b:<definite> = D.t:<definite>
+NP.b:<quan> = D.t:<quan>
+NP.b:<card> = D.t:<card>
+NP.b:<gen> = D.t:<gen>
+NP.b:<decreas> = D.t:<decreas>
+NP.b:<wh> = D.t:<wh>
+NP.b:<case> = nom/acc
+NP.b:<agr num> = sing
+NP.b:<agr pers> = 3
+NP.b:<agr 3rdsing> = +
+P_1.b:<assign-case> = acc
+PP_1.b:<assign-case> = P_1.t:<assign-case>
+PP_1.b:<assign-case> = NP_1.t:<case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_1.b:<wh> = NP_1:<wh>
+V.b:<mode> = ger
+" :COMMENTS "Ditransitive Determiner gerund with PP:
+
+... \"the putting of his reputation on the line\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . ""))) (((("D" . "")) :substp T :constraints ""))  (((("N" . ""))) (((("V" . "")) :headp T))  (((("PP" . "1"))) (((("P" . "1"))) (((("of" . "")))) )  (((("NP" . "1")) :substp T)) )  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive w/out by-phrase:
+	the poodle was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("W0nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_0:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_2:<case> = PP.b:<assign-case>
+NP.t:<agr> = NP_0.t:<agr>
+NP.t:<case> = NP_0.t:<case>
+NP.t:<trace> = NP_0.t:<trace>
+NP.t:<wh> = NP_0.t:<wh>
+NP:<case> = PP_0.b:<assign-case>
+P_0.b:<assign-case> = acc
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction from by-phrase:
+	who was the poodle put in the oven by
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "0")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("pW0nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<wh> = PP_0.t:<wh>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_0:<case> = PP_0.b:<assign-case>
+NP_1:<agr> = VP.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+PP_0.b:<wh> = NP_0:<wh>
+P_0.b:<assign-case> = acc
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0:<trace> = PP.t:<trace>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction of by-phrase:
+	by whom was the poodle put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) 
+("W2nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_2:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_0:<case> = PP_0.b:<assign-case>
+NP_2:<agr> = NP.t:<agr>
+NP_2:<case> = NP.t:<case>
+NP_2:<trace> = NP.t:<trace>
+NP_2:<wh> = NP.t:<wh>
+NP:<case> = PP.b:<assign-case>
+P_0.b:<assign-case> = acc
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<wh> = NP.t:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction of NP2:
+	what was the poodle put in by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "2")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) 
+("W2nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_2:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_2:<agr> = NP.t:<agr>
+NP_2:<case> = NP.t:<case>
+NP_2:<trace> = NP.t:<trace>
+NP_2:<wh> = NP.t:<wh>
+NP:<case> = PP.b:<assign-case>
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<wh> = NP.t:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction of NP2, w/0 by-phrase:
+	what was the poodle put in
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "2")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("N1nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf/ppart
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+NP_w.t:<wh> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction from NP1:
+	(I saw) the dog that was put in the oven by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("N1nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf/ppart
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+NP_w.t:<wh> = +
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+" :COMMENTS "Passive that relative clause, extraction from NP1, w/o by-phrase:
+	(I saw) the dog that was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("W1nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+S_r.t:<conj> = nil
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_1:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_1.t:<wh> = +
+NP_2:<case> = PP.b:<assign-case>
+NP.t:<agr> = NP_1.t:<agr>
+NP.t:<case> = NP_1.t:<case>
+NP.t:<trace> = NP_1.t:<trace>
+NP.t:<wh> = NP_1.t:<wh>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Wh question on NP1 in passive constructions, with by-phrase
+	what was put in the oven by Max
+	
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) 
+("W1nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = inf_nil/ind_nil/ecm
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<inv> = -
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP.t:<agr>
+S_r.b:<assign-case> = NP.t:<case>
+S_r.t:<conj> = nil
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = NP_1.t:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_2:<case> = PP.b:<assign-case>
+NP.t:<agr> = NP_1.t:<agr>
+NP.t:<case> = NP_1.t:<case>
+NP.t:<wh> = +
+NP.t:<trace> = NP_1.t:<trace>
+NP.t:<wh> = NP_1.t:<wh>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Wh question on NP1 in passive constructions, w/o by-phrase
+	what was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("NP" . "1")) :substp T :constraints "" :constraint-type :DUMMY))  (((("S" . "r"))) (((("NP" . "")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) 
+("pW2nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<wh> = PP_2:<wh>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_2:<case> = PP.b:<assign-case>
+PP_2:<trace> = PP.t:<trace>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction of NP2, w/o by-phrase:
+	where was the poodle put by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("pW2nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+
+
+
+
+
+
+
+
+S_r.t:<comp> = nil
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<inv> = -
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+S_q.b:<extracted> = +
+
+S_q.b:<wh> = PP_2:<wh>
+S_q.b:<inv> = S_r.t:<inv>
+S_q.b:<inv> = S_q.b:<invlink>
+S_q.b:<mode> = S_r.t:<mode>
+S_q.b:<comp> = nil
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<agr> = V.t:<agr>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+NP_0:<case> = PP_0.b:<assign-case>
+NP_2:<case> = PP.b:<assign-case>
+PP_2:<trace> = PP.t:<trace>
+P_0.b:<assign-case> = acc
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "passive, extraction of NP2:
+	where was the poodle put by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "q"))) (((("PP" . "")) :constraints "" :constraint-type :DUMMY) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) 
+("N2nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<comp> = nil
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP_2:<case>
+PP_0.b:<wh> = NP_0:<wh>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object
+	(I saw) the oven that the poodle was put in by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
+("N2nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<comp> = nil
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+NP_w.t:<wh> = +
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP_2:<case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
+	(I saw) the oven that the poodle was put in
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("N0nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<comp> = nil
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+NP_w.t:<wh> = +
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+	(I saw) the person that the poodle was put in the oven by
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nbynx0nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_f.b:<refl> = -
+P_0.b:<assign-case> = acc
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+
+NP_w.t:<wh> = +
+S_r.t:<comp> = nil
+PP_w.t:<trace> = PP_0.b:<trace>
+PP_w.t:<case> = PP_0.b:<case>
+PP_w.t:<agr> = PP_0.b:<agr>
+PP_w.b:<assign-case> = P_0.t:<assign-case>
+PP_w.b:<assign-case> = NP_w.t:<case>
+PP_w.b:<wh> = NP_w.t:<wh>
+NP_r.b:<rel-clause> = +
+NP_f.b:<case> = nom/acc
+P.t:<assign-case> = PP.b:<assign-case>
+NP_2:<case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+NP_r.b:<pron> = NP_f.t:<pron>
+
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+	(I saw) the person that the poodle was put in the oven by
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "w")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) 
+("Npxnx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<inv> = -
+S_r.t:<comp> = nil
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "no comments
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Npxnx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<inv> = -
+S_r.t:<comp> = nil
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive:
+	the poodle was put in the oven by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Npxnx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<inv> = -
+S_r.t:<comp> = nil
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive w/out by-phrase:
+	the poodle was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w")) :substp T))  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Npx2nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.t:<mode> = ind/inf
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<comp> = nil
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0.t:<agr> = S_r.b:<agr>
+NP_0.t:<case> = S_r.b:<assign-case>
+NP_1.t:<case> = acc
+NP_2:<case> = PP_w.b:<assign-case>
+PP_w.t:<trace> = PP.b:<trace>
+PP_w.t:<case> = PP.b:<case>
+PP_w.t:<agr> = PP.b:<agr>
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP_w.b:<assign-case>
+PP_w.b:<wh> = NP_2:<wh>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Npx2nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<comp> = nil
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP_w.b:<assign-case>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+PP_w.t:<trace> = PP.b:<trace>
+PP_w.t:<case> = PP.b:<case>
+PP_w.t:<agr> = PP.b:<agr>
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP_w.b:<assign-case>
+PP_w.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object
+	(I saw) the oven that the poodle was put in by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
+("Npx2nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<mode> = ind/inf
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<comp> = nil
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP_w.b:<assign-case>
+PP_w.t:<trace> = PP.b:<trace>
+PP_w.t:<case> = PP.b:<case>
+PP_w.t:<agr> = PP.b:<agr>
+PP_w.t:<wh> = +
+P.t:<assign-case> = PP_w.b:<assign-case>
+PP_w.b:<wh> = NP_2:<wh>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
+	(I saw) the oven that the poodle was put in
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("PP" . "w"))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . "t")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Nc0nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<inv> = -
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_0.t:<agr>
+S_r.b:<assign-case> = NP_0.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<mode> = inf/ger/ind
+S_r.t:<nocomp-mode> = inf/ger
+VP.t:<assign-comp> = that/ind_nil/inf_nil/ecm
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Nc1nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = nom/acc
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_1.t:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Nc2nx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+
+NP_f.b:<case> = nom/acc
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.t:<inv> = -
+S_r.b:<inv> = -
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<tense> = VP.t:<tense>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0.t:<agr> = S_r.b:<agr>
+NP_0.t:<case> = S_r.b:<assign-case>
+NP_1.t:<case> = acc
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP.t:<case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "
+Need to decide what VP agrees with" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("Nc1nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<mode> = inf/ger/ind/ppart
+S_r.t:<nocomp-mode> = ind/ger/ppart
+VP.t:<assign-comp> = that/inf_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction from NP1:
+	(I saw) the dog that was put in the oven by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Nc1nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+NP_f.b:<case> = nom/acc
+
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.t:<mode> = inf/ger/ind/ppart
+S_r.t:<nocomp-mode> = ind/ger/ppart
+VP.t:<assign-comp> = that/inf_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_1.b:<trace>
+NP_w.t:<case> = NP_1.b:<case>
+NP_w.t:<agr> = NP_1.b:<agr>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<assign-comp> = ppart_nil
+V.t:<passive> = +
+" :COMMENTS "Passive that relative clause, extraction from NP1, w/o by-phrase:
+	(I saw) the dog that was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Nc2nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP_2:<case>
+PP_0.b:<wh> = NP_0:<wh>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object
+	(I saw) the oven that the poodle was put in by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) ) ) 
+("Nc2nx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_w.t:<trace> = NP.b:<trace>
+NP_w.t:<case> = NP.b:<case>
+NP_w.t:<agr> = NP.b:<agr>
+PP.b:<assign-case> = P.t:<assign-case>
+PP.b:<assign-case> = NP_2:<case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP2 from indirect object, w/o by-phrase
+	(I saw) the oven that the poodle was put in
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) ) 
+("Nc0nx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.t:<agr> = NP_r.b:<agr>
+NP_f.t:<wh> = NP_r.b:<wh>
+NP_f.t:<case> = NP_r.b:<case>
+NP_f.b:<refl> = -
+
+NP_f.b:<case> = nom/acc
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+
+S_r.b:<comp> = nil
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<agr> = NP_1.t:<agr>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.t:<conj> = nil
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<mode> = inf/ind
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+
+VP.t:<mode> = ind
+VP.b:<passive> = +
+VP.b:<mode> = V.t:<mode>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+NP_2:<case> = PP.b:<assign-case>
+NP_w.t:<trace> = NP_0.b:<trace>
+NP_w.t:<case> = NP_0.b:<case>
+NP_w.t:<agr> = NP_0.b:<agr>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "That relative clause, extraction of NP0 from by-phrase:
+	(I saw) the person that the poodle was put in the oven by
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("" . "")))) ) ) ) ) ) ) 
+("Ncnx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_0.t:<control>
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+S_r.t:<inv> = -
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<case> = S_r.b:<assign-case>
+NP_0:<wh> = -
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+" :COMMENTS "no comments
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Ncnx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+S_r.t:<inv> = -
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive:
+	the poodle was put in the oven by Max
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) ) ) 
+("Ncnx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_f.t:<wh>
+NP_r.b:<agr> = NP_f.t:<agr>
+NP_r.b:<case> = NP_f.t:<case>
+NP_r.b:<rel-clause> = +
+NP_r.b:<pron> = NP_f.t:<pron>
+NP_f.b:<case> = acc/nom
+NP_f.b:<case> = nom/acc
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+
+
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<assign-case> = VP.t:<assign-case>
+S_r.b:<control> = NP_1.t:<control>
+S_r.t:<mode> = ind/inf
+S_r.t:<nocomp-mode> = ind
+VP.t:<assign-comp> = that/for/ind_nil
+S_r.b:<nocomp-mode> = S_r.b:<mode>
+S_r.t:<inv> = -
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-case> = V.t:<assign-case>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<case> = S_r.b:<assign-case>
+NP_1:<wh> = -
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+" :COMMENTS "Passive w/out by-phrase:
+	the poodle was put in the oven
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "f")) :footp T :constraints "NA" :constraint-type :NA))  (((("S" . "p")) :constraints "NA" :constraint-type :NA) (((("NP" . "w")) :constraints "NA" :constraint-type :NA) (((("" . "w")))) )  (((("S" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) ) ) 
+("Gnx0Vnx1pnx2-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+NP_0.t:<wh> = -
+NP_0:<wh> = NP_r.b:<wh>
+NP_0.t:<case> = none
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+
+" :COMMENTS "Ditransitive NP gerund with PP, w/ PRO subject:
+
+\"John did not approve of [PRO putting his reputation on the line]\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "0")) :display-feature? T :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("Gnx1Vpnx2bynx0-PRO" :COMMENT-DISPLAY? T :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_1:<wh>
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+NP_1.t:<case> = none
+NP_1.t:<wh> = -
+NP_0:<case> = PP_0.b:<assign-case>
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P_0.b:<assign-case> = acc
+V.t:<mode> = ppart
+V.t:<passive> = +
+
+" :COMMENTS "Ditransitive (with PP) gerund passive with the \"by\" phrase, w/ PRO subject:
+
+\"John feared [PRO being associated with the criminal element].\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1Vpnx2-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+NP_r.b:<gerund> = +
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+NP_1.t:<case> = none
+NP_1.t:<wh> = -
+NP_1:<wh> = NP_r.b:<wh>
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+
+" :COMMENTS "Ditransitive (with PP) gerund passive without the \"by\" phrase, w/ PRO subject:
+
+\"John feared [PRO being associated with the criminal element].\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("Gnx0Vnx1pnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+
+
+NP_r.b:<gerund> = +
+
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<wh> = NP_r.b:<wh>
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+NP_0:<case> = acc/gen
+" :COMMENTS "Ditransitive NP gerund with PP:
+
+\"John did not approve of \"Mary putting her reputation on the line\"\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "0")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("Gnx1Vpnx2bynx0" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<wh> = NP_1:<wh>
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+
+
+NP_r.b:<gerund> = +
+
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<case> = PP_0.b:<assign-case>
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+P_0.b:<assign-case> = acc
+V.t:<mode> = ppart
+V.t:<passive> = +
+NP_1:<case> = acc/gen
+" :COMMENTS "Ditransitive (with PP) gerund passive with the \"by\" phrase:
+
+\"John feared \"Mary's reputation being put on the line by the reporters\"\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T)) ) ) ) 
+("Gnx1Vpnx2" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+NP_r.b:<case> = nom/acc
+NP_r.b:<agr num> = sing
+NP_r.b:<agr pers> = 3
+NP_r.b:<agr 3rdsing> = +
+
+
+NP_r.b:<gerund> = +
+
+VP.t:<mode> = ger
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<wh> = NP_r.b:<wh>
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+NP_1:<case> = acc/gen
+" :COMMENTS "Ditransitive (with PP) gerund passive without the \"by\" phrase:
+
+\"John feared \"Mary's reputation being put on the line\"\"
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("NP" . "r"))) (((("NP" . "1")) :display-feature? T :substp T :constraints ""))  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("nx0Vnx1pnx2-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_0:<wh>
+S_r.b:<assign-case> = NP_0.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<control> = NP_0.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mode> = V.t:<mode>
+VP.b:<tense> = V.t:<tense>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = VP_e.t:<compar>
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_0:<agr> = S_r.b:<agr>
+NP_0:<wh> = -
+NP_0.t:<case> = none
+NP_1:<case> = acc
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<passive> = -
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "Ditransitive with PP w/ PRO subject:
+
+He didn't want [PRO to put his reputation on the line].
+
+
+
+
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "0")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("NP" . "1")) :substp T :constraints ""))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 
+("nx1Vpnx2bynx0-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<wh> = -
+NP_1.t:<case> = none
+NP_2:<case> = PP.b:<assign-case>
+PP_0.b:<assign-case> = P_0.t:<assign-case>
+PP_0.b:<assign-case> = NP_0.t:<case>
+P_0.b:<assign-case> = acc
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+PP_0.b:<wh> = NP_0:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "Ditransitive with PP Passive w/ PRO subject:
+
+The poodle didn't want [PRO to be put in the oven by Max].
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . "")) :display-feature? T) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) )  (((("PP" . "0"))) (((("P" . "0"))) (((("by" . "")))) )  (((("NP" . "0")) :substp T :constraints "")) ) ) ) 
+("nx1Vpnx2-PRO" :COMMENT-DISPLAY? NIL :FEATURE-DISPLAY? NIL :EQUATION-DISPLAY? NIL :UNIFICATION-EQUATIONS "
+
+S_r.b:<extracted> = -
+S_r.b:<inv> = -
+S_r.b:<assign-comp> = VP.t:<assign-comp>
+S_r.b:<mode> = VP.t:<mode>
+S_r.b:<comp> = nil
+S_r.b:<tense> = VP.t:<tense>
+S_r.b:<wh> = NP_1:<wh>
+S_r.b:<assign-case> = NP_1.t:<case>
+S_r.b:<agr> = VP.t:<agr>
+S_r.b:<control> = NP_1.t:<control>
+S_r.b:<progressive> = VP.t:<progressive>
+S_r.b:<perfect> = VP.t:<perfect>
+S_r.b:<passive> = VP.t:<passive>
+S_r.b:<mainv> = VP.t:<mainv>
+VP.b:<mode> = V.t:<mode>
+VP.b:<passive> = V.t:<passive>
+VP.b:<agr> = V.t:<agr>
+VP.b:<tense> = V.t:<tense>
+VP.b:<assign-comp> = V.t:<assign-comp>
+VP.b:<mainv> = V.t:<mainv>
+VP.b:<compar> = -
+VP_e.b:<mainv> = -
+VP_e.b:<compar> = -
+VP_e.b:<mode> = base
+VP_e.b:<assign-comp> = none
+
+NP_1:<agr> = S_r.b:<agr>
+NP_1:<wh> = -
+NP_1.t:<case> = none
+NP_2:<case> = PP.b:<assign-case>
+P.t:<assign-case> = PP.b:<assign-case>
+PP.b:<wh> = NP_2:<wh>
+V.t:<mode> = ppart
+V.t:<passive> = +
+VP.t:<mode> = inf/ger
+
+" :COMMENTS "Ditransitive with PP Passive w/out by-phrase, w/ PRO subject:
+
+The poodle didn't want [PRO to be put in the oven].
+" :SHAPE NIL :BORDER-WIDTH NIL :CONSTRAINT-STYLE NIL :CONNECTOR NIL :DEFAULT-STYLE NIL :SUBSCRIPT-STYLE NIL :WHITE-SPACE NIL  :MINIMUM-NODE-SEPARATION NIL :LEVEL-SEPARATION NIL)
+ (((("S" . "r"))) (((("NP" . "1")) :constraints "NA" :constraint-type :NA) (((("PRO" . "")))) )  (((("VP" . ""))) (((("V" . "")) :headp T))  (((("VP" . "e"))) (((("V" . "e")) :constraints "NA" :constraint-type :NA) (((("" . "v")))) )  (((("PP" . ""))) (((("P" . "")) :substp T))  (((("NP" . "2")) :substp T)) ) ) ) ) 


### PR DESCRIPTION
Tnx0Vpnx1 and Tnx0Vnx1pnx2 were missing from the dataset. This can happen because of the way different systems handle files with the same names but different cases. I renamed the files to:
Tnx0V_pnx1 and Tnx0Vnx1_pnx2 respectively to avoid this in the future.
